### PR TITLE
Bank: authentication

### DIFF
--- a/bank/handlers.go
+++ b/bank/handlers.go
@@ -11,7 +11,7 @@ type envelope map[string]any
 
 func (s *Server) Routes(r chi.Router) {
 	r.Route("/", func(r chi.Router) {
-		r.Use(AuthorizationCtx())
+		r.Use(AuthenticationCtx())
 		r.Post("/register", s.handleRegisterProxy)
 		r.Post("/deposit", s.handleDeposit)
 		r.Post("/withdraw", s.handleWithdraw)

--- a/bank/middleware.go
+++ b/bank/middleware.go
@@ -10,20 +10,13 @@ import (
 type ctxKey int
 
 const (
-	CtxKeySignature ctxKey = iota
-	CtxKeyAddress
+	CtxKeyAddress ctxKey = iota
 )
 
-func AuthorizationCtx() func(http.Handler) http.Handler {
+func AuthenticationCtx() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			sig, pub, msg, err := ParseHeader(r)
-			if err != nil {
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-				return
-			}
-
-			addr, err := crypto.Address(sig.Type, pub)
+			sig, addr, msg, err := ParseHeader(r)
 			if err != nil {
 				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
@@ -35,7 +28,6 @@ func AuthorizationCtx() func(http.Handler) http.Handler {
 			}
 
 			ctx := r.Context()
-			ctx = context.WithValue(ctx, CtxKeySignature, sig)
 			ctx = context.WithValue(ctx, CtxKeyAddress, addr)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		}

--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -86,7 +86,7 @@ func main() {
 	bankCtx.RegisterValidators()
 
 	httpServer.Log = logger
-	httpServer.RegisterMiddleWare(bank.AuthorizationCtx())
+	httpServer.RegisterMiddleWare(bank.AuthenticationCtx())
 	httpServer.RegisterRoutes(bankCtx.Routes)
 
 	if err := httpServer.Run(); err != nil {


### PR DESCRIPTION
Authentication middleware only needs to rely on the public address, as a string to facilitate the comunication.