### PR TITLE
Bank: authentication

### DIFF
--- a/bank/config.go
+++ b/bank/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
+	"github.com/subvisual/fidl"
 	"github.com/subvisual/fidl/http"
 )
 
@@ -16,7 +17,7 @@ type Db struct {
 }
 
 type Wallet struct {
-	Address string `toml:"address"`
+	Address fidl.Address `toml:"address"`
 }
 
 type Config struct {

--- a/bank/handlers.go
+++ b/bank/handlers.go
@@ -3,8 +3,8 @@ package bank
 import (
 	"net/http"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/go-chi/chi/v5"
+	"github.com/subvisual/fidl"
 )
 
 type envelope map[string]any
@@ -24,9 +24,9 @@ func (s *Server) Routes(r chi.Router) {
 func (s *Server) handleRegisterProxy(w http.ResponseWriter, r *http.Request) {
 	var params RegisterParams
 
-	address, ok := r.Context().Value(CtxKeyAddress).(address.Address)
+	address, ok := r.Context().Value(CtxKeyAddress).(fidl.Address)
 	if !ok {
-		s.JSON(w, r, http.StatusBadRequest, "failed to parse header signature")
+		s.JSON(w, r, http.StatusBadRequest, "failed to parse header address")
 		return
 	}
 
@@ -51,9 +51,9 @@ func (s *Server) handleRegisterProxy(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeposit(w http.ResponseWriter, r *http.Request) {
 	var params DepositParams
 
-	address, ok := r.Context().Value(CtxKeyAddress).(address.Address)
+	address, ok := r.Context().Value(CtxKeyAddress).(fidl.Address)
 	if !ok {
-		s.JSON(w, r, http.StatusBadRequest, "failed to parse header signature")
+		s.JSON(w, r, http.StatusBadRequest, "failed to parse header address")
 		return
 	}
 
@@ -79,9 +79,9 @@ func (s *Server) handleDeposit(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleWithdraw(w http.ResponseWriter, r *http.Request) {
 	var params WithdrawParams
 
-	address, ok := r.Context().Value(CtxKeyAddress).(address.Address)
+	address, ok := r.Context().Value(CtxKeyAddress).(fidl.Address)
 	if !ok {
-		s.JSON(w, r, http.StatusBadRequest, "failed to parse header signature")
+		s.JSON(w, r, http.StatusBadRequest, "failed to parse header address")
 		return
 	}
 
@@ -105,9 +105,9 @@ func (s *Server) handleWithdraw(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBalance(w http.ResponseWriter, r *http.Request) {
-	address, ok := r.Context().Value(CtxKeyAddress).(address.Address)
+	address, ok := r.Context().Value(CtxKeyAddress).(fidl.Address)
 	if !ok {
-		s.JSON(w, r, http.StatusBadRequest, "failed to parse header signature")
+		s.JSON(w, r, http.StatusBadRequest, "failed to parse header address")
 		return
 	}
 
@@ -123,9 +123,9 @@ func (s *Server) handleBalance(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	var params AuthorizeParams
 
-	_, ok := r.Context().Value(CtxKeyAddress).(address.Address)
+	_, ok := r.Context().Value(CtxKeyAddress).(fidl.Address)
 	if !ok {
-		s.JSON(w, r, http.StatusBadRequest, "failed to parse header signature")
+		s.JSON(w, r, http.StatusBadRequest, "failed to parse header address")
 		return
 	}
 
@@ -147,9 +147,9 @@ func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleRedeem(w http.ResponseWriter, r *http.Request) {
 	var params RedeemParams
 
-	_, ok := r.Context().Value(CtxKeyAddress).(address.Address)
+	_, ok := r.Context().Value(CtxKeyAddress).(fidl.Address)
 	if !ok {
-		s.JSON(w, r, http.StatusBadRequest, "failed to parse header signature")
+		s.JSON(w, r, http.StatusBadRequest, "failed to parse header address")
 		return
 	}
 

--- a/bank/middleware.go
+++ b/bank/middleware.go
@@ -22,7 +22,7 @@ func AuthenticationCtx() func(http.Handler) http.Handler {
 				return
 			}
 
-			if err := crypto.Verify(sig, addr, []byte(msg)); err != nil {
+			if err := crypto.Verify(sig, *addr.Address, msg); err != nil {
 				http.Error(w, "failed to verify signature", http.StatusUnauthorized)
 				return
 			}

--- a/cmd/bank/main.go
+++ b/cmd/bank/main.go
@@ -81,7 +81,7 @@ func main() {
 
 	bankCtx := bank.Server{HTTP: httpServer}
 	bankCtx.BankService = postgres.NewBankService(db, &postgres.BankConfig{
-		WalletAddress: cfg.Wallet.Address,
+		WalletAddress: cfg.Wallet.Address.String(),
 	})
 	bankCtx.RegisterValidators()
 

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -1,30 +1,17 @@
 package crypto
 
 import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/venus/pkg/crypto"
 	_ "github.com/filecoin-project/venus/pkg/crypto/secp" // to run init()
+	"github.com/subvisual/fidl"
 )
-
-func Address(sigType crypto.SigType, pubkey []byte) (address.Address, error) {
-	var addr address.Address
-	var err error
-
-	switch sigType {
-	case crypto.SigTypeSecp256k1:
-		addr, err = address.NewSecp256k1Address(pubkey)
-	default:
-		err = fmt.Errorf("no valid signature type: %v", sigType)
-	}
-
-	if err != nil {
-		return address.Address{}, fmt.Errorf("failed to get address from pubkey: %w", err)
-	}
-
-	return addr, nil
-}
 
 func Verify(sig *crypto.Signature, addr address.Address, msg []byte) error {
 	if err := crypto.Verify(sig, addr, msg); err != nil {
@@ -34,26 +21,25 @@ func Verify(sig *crypto.Signature, addr address.Address, msg []byte) error {
 	return nil
 }
 
-func GeneratePrivate(sigType crypto.SigType) ([]byte, error) {
-	pk, err := crypto.Generate(sigType)
+func Sign(wallet fidl.Wallet, msg []byte) (*crypto.Signature, error) {
+	var keyInfo KeyInfo
+
+	pkIn, err := os.ReadFile(wallet.Path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate private key: %w", err)
+		return nil, fmt.Errorf("failed to load private key: %w", err)
 	}
 
-	return pk, nil
-}
-
-func PrivateToPublic(sigType crypto.SigType, pk []byte) ([]byte, error) {
-	pub, err := crypto.ToPublic(sigType, pk)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert to public key: %w", err)
+	pkIn = bytes.TrimRight(pkIn, "\n")
+	pkOut := make([]byte, hex.DecodedLen(len(pkIn)))
+	if _, err := hex.Decode(pkOut, pkIn); err != nil {
+		return nil, fmt.Errorf("failed to decode private key: %w", err)
 	}
 
-	return pub, nil
-}
+	if err := json.Unmarshal(pkOut, &keyInfo); err != nil {
+		return nil, fmt.Errorf("failed to convert private key: %w", err)
+	}
 
-func Sign(msg []byte, pk []byte, sigType crypto.SigType) (*crypto.Signature, error) {
-	sig, err := crypto.Sign(msg, pk, sigType)
+	sig, err := crypto.Sign(msg, keyInfo.PrivateKey, keyInfo.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign message: %w", err)
 	}

--- a/crypto/types.go
+++ b/crypto/types.go
@@ -1,0 +1,56 @@
+package crypto
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/filecoin-project/go-state-types/crypto"
+)
+
+type KeyInfo struct {
+	Type       crypto.SigType
+	PrivateKey []byte
+}
+
+type (
+	Signature = crypto.Signature
+)
+
+const (
+	SigTypeUnknown   = crypto.SigTypeUnknown
+	SigTypeSecp256k1 = crypto.SigTypeSecp256k1
+	SigTypeBLS       = crypto.SigTypeBLS
+	SigTypeDelegated = crypto.SigTypeDelegated
+)
+
+func (ki *KeyInfo) UnmarshalJSON(value []byte) error {
+	type KeyInfo struct {
+		Type       string
+		PrivateKey []byte
+	}
+
+	var keyInfo KeyInfo
+
+	err := json.Unmarshal(value, &keyInfo)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal type: %w", err)
+	}
+
+	secp, _ := SigTypeSecp256k1.Name()
+	bls, _ := SigTypeBLS.Name()
+	del, _ := SigTypeDelegated.Name()
+	ki.PrivateKey = keyInfo.PrivateKey
+
+	switch keyInfo.Type {
+	case secp:
+		ki.Type = SigTypeSecp256k1
+	case bls:
+		ki.Type = SigTypeBLS
+	case del:
+		ki.Type = SigTypeDelegated
+	default:
+		ki.Type = SigTypeUnknown
+	}
+
+	return nil
+}

--- a/etc/bank.ini.example
+++ b/etc/bank.ini.example
@@ -21,4 +21,4 @@ max-idle-connections=25
 max-idle-time="15m"
 
 [wallet]
-public-key="bank public key"
+address="f1qbvbikeuozxgoop5bc7nkcokapslxxdy2gucfqa"

--- a/fidl.go
+++ b/fidl.go
@@ -3,6 +3,7 @@ package fidl
 import (
 	"database/sql"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -14,6 +15,22 @@ var (
 )
 
 type FIL float64
+
+type Wallet struct {
+	Path    string  `toml:"path"`
+	Address Address `toml:"address"`
+}
+
+type Address struct {
+	*address.Address
+}
+
+func (a *Address) UnmarshalText(value []byte) error {
+	addr, err := address.NewFromString(string(value))
+	a.Address = &addr
+
+	return err // nolint:wrapcheck
+}
 
 type Queryable interface {
 	Get(dest interface{}, query string, args ...interface{}) error

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/filecoin-project/go-address v1.2.0
+	github.com/filecoin-project/go-state-types v0.14.0
 	github.com/filecoin-project/venus v1.16.2
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-chi/cors v1.2.1
@@ -18,7 +19,6 @@ require (
 
 require (
 	github.com/filecoin-project/go-crypto v0.1.0 // indirect
-	github.com/filecoin-project/go-state-types v0.14.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect

--- a/http.go
+++ b/http.go
@@ -1,9 +1,0 @@
-package fidl
-
-import "net/http"
-
-func SetHeaders(w http.ResponseWriter, status int) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.WriteHeader(status)
-}


### PR DESCRIPTION
- Authentication parameters being sent on the headers of the requests
- Using hex encoding to decode the signature and message
- Some types were moved to the `crypto` package (will solve this repo architecture on next prs)